### PR TITLE
Change find to look by id rather than by name.

### DIFF
--- a/validate_helper.js
+++ b/validate_helper.js
@@ -33,7 +33,7 @@ validate: function( callback ) {
               $.each(errors, function (index, err) {
                 // Displays the erros message in the help-block
                 var $target = $this
-                    .find("*[name='" + err.id + "']")
+                    .find("*[id='" + err.id + "']")
                     .next(".help-block")
                     .html(err.message)
                 // Adds error class to the controlgroup (bootstrap)


### PR DESCRIPTION
The validate.js library returns the id of the element with the error. In your examples, the name and the id were identical, so it didn't make a difference - but when I tried using your plugin with the names and the ids being different, the 
    find(*[id='" + err.id + "']")
didn't return any elements in my form (since the id didn't match the name). So you should either specify in the README that the name should match the id, or do call the find method with the id instead (hence my code).

Best,
Pasha
